### PR TITLE
Feat: Thêm tùy chọn Self Listen cho Message trigger

### DIFF
--- a/nodes/ZaloMessageTrigger/ZaloMessageTrigger.node.ts
+++ b/nodes/ZaloMessageTrigger/ZaloMessageTrigger.node.ts
@@ -63,6 +63,14 @@ export class ZaloMessageTrigger implements INodeType {
 				required: true,
 				description: 'Types of messages to listen for',
 			},
+			{
+				displayName: 'Self Listen',
+				name: 'selfListen',
+				type: 'boolean',
+				default: false,
+				required: true,
+				description: 'Whether to listen to messages sent by yourself',
+			},
 		],
 	};
 
@@ -85,7 +93,8 @@ export class ZaloMessageTrigger implements INodeType {
 					const imeiFromCred = credentials.imei as string;
 					const userAgentFromCred = credentials.userAgent as string;
 
-					const zalo = new Zalo();
+					const selfListen = this.getNodeParameter('selfListen', 0) as boolean;
+					const zalo = new Zalo({ selfListen });
 					api = await zalo.login({ cookie: cookieFromCred, imei: imeiFromCred, userAgent: userAgentFromCred });
 
 					if (!api) {
@@ -95,7 +104,7 @@ export class ZaloMessageTrigger implements INodeType {
 						);
 					}
                     const webhookUrl = this.getNodeWebhookUrl('default') as string;
-                    console.log(webhookUrl)
+                    console.log(webhookUrl);
 					// Add message event listener
 					api.listener.on('message', async (message) => {
 						const webhookData = this.getWorkflowStaticData('node');

--- a/nodes/ZaloMessageTrigger/ZaloMessageTrigger.node.ts
+++ b/nodes/ZaloMessageTrigger/ZaloMessageTrigger.node.ts
@@ -69,7 +69,7 @@ export class ZaloMessageTrigger implements INodeType {
 				type: 'boolean',
 				default: false,
 				required: true,
-				description: 'Whether to listen to messages sent by yourself',
+				description: 'Cho phép lắng nghe tin nhắn của chính mình tự gửi',
 			},
 		],
 	};
@@ -177,4 +177,4 @@ export class ZaloMessageTrigger implements INodeType {
 			workflowData: [this.helpers.returnJsonArray(req.body)],
 		};
 	}
-} 
+}


### PR DESCRIPTION
Bổ sung option "Self Listen" vào cài đặt của Message Trigger. Tùy chọn này cho phép người dùng kiểm soát xem trigger có kích hoạt khi nhận được tin nhắn do chính họ gửi đi hay không.

Tính năng này giúp người dùng linh hoạt hơn trong việc điều khiển luồng xử lý (workflow) của hệ thống. Cụ thể, nó có thể được sử dụng để BẬT/TẮT tạm thời một số bước xử lý trong workflow.

Ví dụ ứng dụng:

Hãy tưởng tượng một workflow đơn giản: khi nhận được bất kỳ tin nhắn nào, hệ thống sẽ sử dụng Gemini để trả lời tự động. Tuy nhiên, trong một cuộc trò chuyện cụ thể, bạn muốn tự mình trả lời mà không để AI can thiệp.

Với tùy chọn "Self Listen", bạn có thể thiết lập như sau:

BẬT "Self Listen" trong Message trigger, lắng nghe các tin nhắn do bạn gửi có nội dung đặc biệt, ví dụ: /ai stop.
Khi nhận được tin nhắn này nó sẽ thực hiện một hành động nào đó trong workflow, ví dụ: thiết lập một biến (flag) đánh dấu rằng AI nên tạm dừng trả lời trong cuộc trò chuyện này.
Bước xử lý Gemini trả lời tin nhắn trong workflow sẽ kiểm tra giá trị của biến (flag) này. Nếu flag đang BẬT (do bạn gửi /ai stop), bước Gemini sẽ bị bỏ qua.