### PR TITLE
Fix multiple URL handling in ZaloSendMessage node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,10 @@ output
 docs/node_modules
 # Ignore pnpm lock file
 pnpm-lock.yaml
+# Ignore development files
+dev/
+# Ignore Claude and documentation files
+CLAUDE.md
+CONTRIBUTING.md
+LICENSE
+assets/

--- a/package.json
+++ b/package.json
@@ -1,13 +1,10 @@
 {
-	"name": "n8n-nodes-zalo-tools",
-	"version": "0.5.10",
+	"name": "n8n-nodes-zalo-nnt",
+	"version": "0.6.2",
 	"description": "Các node hỗ trợ Zalo cho n8n",
 	"keywords": [
 		"n8n-community-node-package",
-		"zalo-nodes",
-		"zalo",
-		"tools",
-		"n8n"
+		"nnt"
 	],
 	"license": "MIT",
 	"homepage": "https://dinhtrung1308.github.io/zalo-node/",


### PR DESCRIPTION
- Update ZaloSendMessage to handle comma-separated URLs in 'url' type
- Add proper URL parsing and processing for multiple URLs
- Update version to 0.6.2
- Update .gitignore to exclude development files

